### PR TITLE
Bump Python version to 3.9-3.14

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,18 +37,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         # Our minimum numpy 1 supported and latest numpy 2
-        # Can't test numpy 1.21 & 1.22, but the lost in type-safety is minimal
         numpy-version: ["numpy>=2"]
         # To save on workflow runtime, only test old numpy on extreme ends of Python version
         # This should at least ensure support for oldest combination
         # and let us know when newest numpy drops support for any Python version
         include:
-          - python-version: "3.8"
-            numpy-version: "numpy==1.23.*"
-          - python-version: "3.13"
-            numpy-version: "numpy==1.23.*"
+          - python-version: "3.9"
+            numpy-version: "numpy==1.25.*"
+          - python-version: "3.14"
+            numpy-version: "numpy==1.26.*" # Fixes distutils removal issue with setuptools
     steps:
       - name: Checkout ${{ github.repository }}/${{ github.ref }}
         uses: actions/checkout@v4
@@ -68,18 +67,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         # Our minimum numpy 1 supported and latest numpy 2
-        # Can't test numpy 1.21 & 1.22, but the lost in type-safety is minimal
         numpy-version: ["numpy>=2"]
         # To save on workflow runtime, only test old numpy on extreme ends of Python version
         # This should at least ensure support for oldest combination
         # and let us know when newest numpy drops support for any Python version
         include:
-          - python-version: "3.8"
-            numpy-version: "numpy==1.23.*"
-          - python-version: "3.13"
-            numpy-version: "numpy==1.23.*"
+          - python-version: "3.9"
+            numpy-version: "numpy==1.25.*"
+          - python-version: "3.14"
+            numpy-version: "numpy==1.26.*" # Fixes distutils removal issue with setuptools
     steps:
       - name: Checkout ${{ github.repository }}/${{ github.ref }}
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0
+
+* Bumped the minimum Python version to 3.9
+  * Incidentally, this bumps the minimum version of numpy to 1.25
+* Set the minimum NumPy version to 1.26.0 on Python 3.12+
+* Added explicit `torch < 2.9.0 ; python_version < '3.10'` version pin to help resolvers that don't account for lack of sdist or wheel like <https://github.com/astral-sh/uv/issues/9647>
+* Added tests for Python 3.14
+
 ## 1.0.1
 
 * Fixed overloads fallback to base `CaptureOutput`

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 strict = True
-python_version = 3.8
+python_version = 3.9
 
 # Ctypes pointers make it impossible to get the right types
 disable_error_code = attr-defined, no-any-return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "typed-D3DShot"
-version = "1.0.2"
+version = "1.1.0"
 description = "Extremely Fast, Robust, and Typed, Screen Capture on Windows with the Desktop Duplication API"
 readme = "README.md"
 authors = [{ name = "Nicholas Brochu", email = "nicholas@serpent.ai" }]
@@ -30,17 +30,17 @@ classifiers = [
   "Operating System :: Microsoft :: Windows :: Windows 10",
   "Operating System :: Microsoft :: Windows :: Windows 11",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Multimedia :: Graphics",
   "Topic :: Multimedia :: Graphics :: Capture",
   "Topic :: Multimedia :: Graphics :: Capture :: Screen Capture",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 dependencies = [
   "comtypes >= 1.1.7 ; python_version < '3.13'",
   "comtypes >= 1.4.8 ; python_version >= '3.13'",
@@ -52,11 +52,18 @@ dependencies = [
 PIL = ["pillow >= 9.1.0"]
 
 numpy = [
-  "numpy >= 1.21.0", # First py.typed version w/ numpy.typing.NDArray
-  "numpy >= 1.25.0 ; python_version >= '3.9'",
+  "numpy >= 1.25.0 ; python_version >= '3.9'", # Disambiguate for uv by adding a Python 3.9 resolution
+  "numpy >= 1.26.0 ; python_version >= '3.12'", # Fixes distutils removal issue with setuptools
 ]
-# First py.typed version
-torch = ["torch >= 2.0.0", "typed-D3DShot[numpy]"]
+
+torch = [
+  "typed-D3DShot[numpy]",
+  "torch >= 2.0.0", # First py.typed version
+  # UV's resolver doesn't account for lack of sdist or wheel https://github.com/astral-sh/uv/issues/9647
+  # PyTorch 2.9.0 doesn't have Python 3.9 wheels
+  "torch < 2.9.0 ; python_version < '3.10'",
+]
+
 dev = ["mypy ~= 1.12.1", "pyright == 1.1.385", "ruff ~= 0.7.0"]
 
 [project.urls]


### PR DESCRIPTION
* Bumped the minimum Python version to 3.9
  * Incidentally, this bumps the minimum version of numpy to 1.25
* Set the minimum NumPy version to 1.26.0 on Python 3.12+
* Added explicit `torch < 2.9.0 ; python_version < '3.10'` version pin to help resolvers that don't account for lack of sdist or wheel like <https://github.com/astral-sh/uv/issues/9647>
* Added tests for Python 3.14